### PR TITLE
feat(autoReconnect) Add autoReconnect option to reconnect on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const logger = new(winston.Logger)({
 * __name__:  Transport name
 * __level__: Level of messages this transport should log. (default: info)
 * __silent__: Boolean flag indicating whether to suppress output. (default: false)
+* __autoReconnect__: Boolean flag indicating whether to reconnect on error. (default: false)
 * __graylogHost__: your server address (default: localhost)
 * __graylogPort__: your server port (default: 12201)
 * __graylogFlag__: Required on LDP Alpha

--- a/lib/ovh-winston-ldp.js
+++ b/lib/ovh-winston-ldp.js
@@ -18,6 +18,7 @@ class OvhWinstonLDP extends winston.Transport {
         let extendedOptions = Object.assign({
             level: "info",
             silent: false,
+            autoReconnect: false,
             graylogHost: "discover.logs.ovh.com",
             graylogPort: 12202,
             graylogHostname: OS.hostname(),
@@ -65,6 +66,11 @@ class OvhWinstonLDP extends winston.Transport {
         this.client.on("error", (err) => {
             this.client.end();
             console.log("[FATAL LOGGER]", err);
+
+            if (this.autoReconnect) {
+                delete this.connecting;
+                this.client = null;
+            }
         });
 
         return;


### PR DESCRIPTION
Hi !

Sometimes our connection is closed and the logger goes FATAL without trying any reconnection.

This PR add an option autoReconnect that will try to reconnect after an error.

How to test ?

Just set autoReconnect to true, start an app, disconnect the network and wait for the logger to timeout and then reconnect to the network : It will try to reconnect on next log.